### PR TITLE
feat(vector-db): add cve_packages table

### DIFF
--- a/.github/workflows/import_packages.yml
+++ b/.github/workflows/import_packages.yml
@@ -47,6 +47,7 @@ jobs:
         MALICIOUS_KEY=$(jq -r '.latest.malicious_packages' manifest.json)
         DEPRECATED_KEY=$(jq -r '.latest.deprecated_packages' manifest.json)
         ARCHIVED_KEY=$(jq -r '.latest.archived_packages' manifest.json)
+        VULNERABLE_KEY=$(jq -r '.latest.vulnerable_packages' manifest.json)
         
         echo "Malicious key: $MALICIOUS_KEY"
         echo "Deprecated key: $DEPRECATED_KEY"
@@ -58,6 +59,7 @@ jobs:
         aws s3 cp s3://codegate-data-prod/$MALICIOUS_KEY /tmp/jsonl-files/malicious.jsonl --region $AWS_REGION
         aws s3 cp s3://codegate-data-prod/$DEPRECATED_KEY /tmp/jsonl-files/deprecated.jsonl --region $AWS_REGION
         aws s3 cp s3://codegate-data-prod/$ARCHIVED_KEY /tmp/jsonl-files/archived.jsonl --region $AWS_REGION
+        aws s3 cp s3://codegate-data-prod/$VULNERABLE_KEY /tmp/jsonl-files/vulnerable.jsonl --region $AWS_REGION
 
     - name: Install Poetry
       run: |


### PR DESCRIPTION
This PR introduces a new table, cve_packages, to store package-version pairs that have at least one vulnerability classified as high or critical. The goal is to have the data ready from when we are going to have the dependecy list exported, this data are being generate by the github action and it is a manual trigger

Changes

Added a new table cve_packages with the following fields:
- 	name (TEXT, NOT NULL) – package name
- 	version (TEXT, NOT NULL) – package version
- 	type (TEXT, NOT NULL) – package type (e.g., npm, pypi)

Created indexes on the name, name:version, and name:version:type fields to optimize queries.
Modified import_packages.py to process and insert package versions with high/critical vulnerabilities into cve_packages.
	
	
